### PR TITLE
feat: add new type and generic to notification repository

### DIFF
--- a/src/models/Notification/NewNotification.ts
+++ b/src/models/Notification/NewNotification.ts
@@ -1,0 +1,22 @@
+export type Recipient =
+  | {
+      email: string;
+    }
+  | {
+      external_id: string;
+    }
+  | { matches: string };
+
+/**
+ * Interface used for the creation of new notifications
+ * to send to the MagicBell API
+ */
+export interface NewNotification {
+  title: string;
+  category?: string;
+  content?: string;
+  action_url?: string;
+  recipients: Array<Recipient>;
+  custom_attributes?: Record<string, any>;
+  topic?: string;
+}

--- a/src/models/Notification/NewNotification.ts
+++ b/src/models/Notification/NewNotification.ts
@@ -17,6 +17,6 @@ export interface NewNotification {
   content?: string;
   action_url?: string;
   recipients: Array<Recipient>;
-  custom_attributes?: Record<string, any>;
+  custom_attributes?: Record<string, unknown>;
   topic?: string;
 }

--- a/src/models/Notification/Notification.ts
+++ b/src/models/Notification/Notification.ts
@@ -4,6 +4,7 @@ import { secondsToDate, toUnix } from '../../lib/date';
 import camelize from '../../lib/decorators/camelize';
 import unwrap from '../../lib/decorators/unwrap';
 import wrap from '../../lib/decorators/wrap';
+import { NewNotification } from './NewNotification';
 import NotificationFactory from './NotificationFactory';
 import NotificationRepository from './NotificationRepository';
 
@@ -34,11 +35,11 @@ export default class Notification {
   }
 
   @wrap('notification')
-  static async create(json) {
+  static async create(notificationContent: NewNotification) {
     const repo = new NotificationRepository();
 
     try {
-      const data = await repo.create(json);
+      const data = await repo.create(notificationContent);
       return NotificationFactory.create(data);
     } catch (error) {
       if (error.response?.status === 422) throw error.response.data;

--- a/src/models/Notification/NotificationRepository.ts
+++ b/src/models/Notification/NotificationRepository.ts
@@ -1,6 +1,7 @@
 import { postAPI } from '../../lib/ajax';
 import RemoteRepository from '../../repository/RemoteRepository';
 import IRemoteNotification from './IRemoteNotification';
+import { NewNotification } from './NewNotification';
 
 /**
  * Class to interact with the notification API endpoints.
@@ -9,7 +10,7 @@ import IRemoteNotification from './IRemoteNotification';
  * const repo = new NotificationRepository();
  * const notifications = repo.findBy({ unseen: true });
  */
-export default class NotificationRepository extends RemoteRepository<IRemoteNotification> {
+export default class NotificationRepository extends RemoteRepository<IRemoteNotification, NewNotification> {
   constructor(remotePathOrUrl = '/notifications') {
     super(remotePathOrUrl);
   }

--- a/src/repository/RemoteRepository.ts
+++ b/src/repository/RemoteRepository.ts
@@ -8,7 +8,9 @@ import IWriter from './IWriter';
  * @example
  * class NotificationRepo extends RemoteRepository<Notification> {}
  */
-export default abstract class RemoteRepository<T> implements IReader<T>, IWriter<T> {
+export default abstract class RemoteRepository<RemoteType, CreationType = RemoteType>
+  implements IReader<RemoteType>, IWriter<CreationType>
+{
   remotePathOrUrl: string;
 
   constructor(remotePathOrUrl: string) {
@@ -21,7 +23,7 @@ export default abstract class RemoteRepository<T> implements IReader<T>, IWriter
    * @example
    * const notification = await repo.get('3df592eb-5f09dd6b');
    */
-  get(id: string | number): Promise<T> {
+  get(id: string | number): Promise<RemoteType> {
     const url = `${this.remotePathOrUrl}/${id}`;
     return fetchAPI(url);
   }
@@ -32,15 +34,15 @@ export default abstract class RemoteRepository<T> implements IReader<T>, IWriter
    * @example
    * const notifications = await repo.findBy({ unread: true });
    */
-  findBy(queryParams: any): Promise<T[]> {
+  findBy(queryParams: any): Promise<RemoteType[]> {
     return fetchAPI(this.remotePathOrUrl, queryParams);
   }
 
-  create(item: T): Promise<T> {
+  create(item: CreationType): Promise<CreationType> {
     return postAPI(this.remotePathOrUrl, item);
   }
 
-  update(id: string | number, item: T): Promise<T> {
+  update(id: string | number, item: CreationType): Promise<CreationType> {
     const url = `${this.remotePathOrUrl}/${id}`;
     return putAPI(url, item);
   }


### PR DESCRIPTION
When creating new events via the `Notification.create` method the parameter for the new notification is any which makes it quite hard to use for new users. This PR adds a new Interface which has the types from https://www.magicbell.com/docs/rest-api/reference#create-notification